### PR TITLE
[Feat] Restart 기능 보완

### DIFF
--- a/Python_dinosaur_game/dino_step3_final.py
+++ b/Python_dinosaur_game/dino_step3_final.py
@@ -126,6 +126,7 @@ def menu(death_count):
     base_path = os.path.dirname(__file__)
     while run:
         font = pygame.font.Font('freesansbold.ttf', 30)
+        small_font = pygame.font.Font('freesansbold.ttf', 20)  # 추가: 작은 글씨체 설정
         RunDino = pygame.image.load(os.path.join(base_path, 'images/Dino/DinoRun1.png'))
         GameoverImg = pygame.image.load(os.path.join(base_path, 'images/Other/Gameover.png'))
         ResetImg = pygame.image.load(os.path.join(base_path, 'images/Other/Reset.png'))
@@ -146,11 +147,25 @@ def menu(death_count):
             screen.blit(GameoverImg, gameoverRect)
             screen.blit(ResetImg, resetRect)
 
+            # 추가: "Press any Key to RESTART" 문구 표시
+            restart_text1 = small_font.render("or", True, (0, 0, 0))
+            restart_text2 = small_font.render("Press any Key to RESTART", True, (0, 0, 0))
+
+            restart_text1_rect = restart_text1.get_rect(center=(MAX_WIDTH // 2, MAX_HEIGHT // 2 + 100))
+            restart_text2_rect = restart_text2.get_rect(center=(MAX_WIDTH // 2, MAX_HEIGHT // 2 + 130))
+
+            screen.blit(restart_text1, restart_text1_rect.topleft)
+            screen.blit(restart_text2, restart_text2_rect.topleft)
+
         pygame.display.update()
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 exit(1)
             if event.type == pygame.KEYDOWN:
                 main()
+            if event.type == pygame.MOUSEBUTTONDOWN:
+                mouse_pos = event.pos
+                if resetRect.collidepoint(mouse_pos): # restart 이미지 클릭하면 재시작
+                    main()
 
 menu(death_count=0)


### PR DESCRIPTION
<img width="790" alt="스크린샷 2024-06-04 오후 2 44 14" src="https://github.com/Joo-Nick/OSS-Project/assets/127292146/44c5b362-3ff7-4f4f-9d37-c7caf78590a5">

게임 종료 화면의 Restart 부분을 수정 및 보완했습니다.
1. pygame.display.update()에서 기존 코드는 게임 종료시 pygame.KEYDOWN으로만 게임이 재시작하도록 했습니다. 따라서 ResetImg가 아무런 동작도 하지 못하는 상황이었습니다. 이를 보완하기 위해 pygame.MOUSEBUTTONDOWN을 추가하고, resetRect.collidepoint(mouse_pos) 등의 코드로 restart 이미지 클릭하면 재시작하도록 보완했습니다.
2. pygame.KEYDOWN으로도 게임이 재시작하므로 "Press any Key to RESTART"라는 문구도 추가했습니다.